### PR TITLE
Add terminal Graphlogue viewer and SWE chat tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+.graphlogue/
+DELIVERABLES.md
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -70,6 +70,52 @@ Run the turnkey governance check (engine must be running locally):
 
 The script asks the engine to generate and execute a `governance_check` API that runs `cargo fmt`, `cargo clippy`, `cargo test`, verifies `conversation.md`, and stores a detailed receipt under `logs/`. Results are summarised in the generated report and appended to `conversation.md` for easy review.
 
+## 🧰 Graphlogue Terminal Tools
+
+The repository now ships with a lightweight terminal experience for tracking live runs, surfacing stakeholder deliverables, and chatting with the engine asynchronously.
+
+### Install prerequisites
+
+The CLI uses standard Unix tooling. Install `jq` and `fzf` if they are not already available:
+
+```bash
+brew install jq fzf          # macOS
+sudo apt-get install jq fzf  # Debian/Ubuntu
+```
+
+### Inspect a run graph
+
+```bash
+# Stream events from progress.sse for an existing run
+./bin/graphlogue run <RUN_ID>
+
+# Load a sample timeline without connecting to an engine
+./bin/graphlogue demo
+```
+
+Every event is persisted under `.graphlogue/` as TSV files (`nodes.tsv`, `edges.tsv`, `deliverables.tsv`). Deliverable events such as `deliverable`, `receipt.write`, `deeplink`, and `kpi` are automatically tracked.
+
+### Deliverables feed and exports
+
+```bash
+# Open the fuzzy finder feed (falls back to a simple list when fzf is missing)
+./bin/graphlogue deliver
+
+# Generate a stakeholder-ready summary document
+./bin/graphlogue export --output DELIVERABLES.md
+```
+
+The deliverables feed lets you open links, inspect receipts, and review generated tables directly from the terminal.
+
+### Async SWE-style chat
+
+```bash
+# Stream chat tokens from /chat when available and fall back to the conversation API otherwise
+./bin/swechat "Add a README badge with status"
+```
+
+Chat sessions reuse a cached conversation branch under `.graphlogue/swechat_session.json`, giving a lightweight async workflow without leaving the terminal.
+
 ## 💡 Example Usage
 
 ### Execute a Goal

--- a/bin/graphlogue
+++ b/bin/graphlogue
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Entry point for the Graphlogue CLI."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from graphlogue.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/swechat
+++ b/bin/swechat
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Entry point for the SWE chat helper."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from graphlogue.swechat import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/graphlogue/__init__.py
+++ b/graphlogue/__init__.py
@@ -1,0 +1,9 @@
+"""Graphlogue terminal tooling package."""
+
+__all__ = [
+    "cli",
+    "demo",
+    "sse",
+    "store",
+    "swechat",
+]

--- a/graphlogue/cli.py
+++ b/graphlogue/cli.py
@@ -1,0 +1,198 @@
+"""Command line entrypoint for the Graphlogue terminal viewer."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import textwrap
+from typing import Optional
+
+from . import demo
+from .store import DeliverableRecord, GraphlogueStore
+from . import sse
+
+DEFAULT_ENGINE_URL = "http://127.0.0.1:8080"
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    store = GraphlogueStore(Path(args.root).resolve())
+
+    if args.command == "demo":
+        return run_demo(store)
+    if args.command == "run":
+        return run_stream(store, args)
+    if args.command == "deliver":
+        return show_deliverables(store)
+    if args.command == "export":
+        return export_deliverables(store, Path(args.output))
+
+    parser.print_help()
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Graphlogue terminal toolkit")
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Project root containing the .graphlogue directory (default: current directory)",
+    )
+
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("demo", help="Load demo events into the deliverables store")
+
+    run_parser = sub.add_parser("run", help="Follow a live progress.sse stream")
+    run_parser.add_argument("run_id", help="Run identifier to follow")
+    run_parser.add_argument(
+        "--engine-url",
+        help="Override ENGINE_URL",
+    )
+    run_parser.add_argument(
+        "--api-key",
+        default=os.environ.get("ENGINE_API_KEY"),
+        help="API key to attach as X-API-Key header",
+    )
+    run_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=30,
+        help="HTTP timeout in seconds for SSE connection (default: 30)",
+    )
+
+    sub.add_parser("deliver", help="Open the deliverables feed")
+
+    export_parser = sub.add_parser("export", help="Write a DELIVERABLES.md summary")
+    export_parser.add_argument(
+        "--output",
+        default="DELIVERABLES.md",
+        help="Destination markdown file (default: DELIVERABLES.md)",
+    )
+
+    return parser
+
+
+def run_demo(store: GraphlogueStore) -> int:
+    store.reset()
+    for event in demo.demo_events():
+        store.register_event(event)
+    print("Loaded demo run into .graphlogue")
+    print("Try `graphlogue deliver` or `graphlogue export`.\n")
+    return 0
+
+
+def run_stream(store: GraphlogueStore, args: argparse.Namespace) -> int:
+    engine_url = args.engine_url or os.environ.get("ENGINE_URL", DEFAULT_ENGINE_URL)
+    url = f"{engine_url.rstrip('/')}/runs/{args.run_id}/progress.sse"
+    headers = {"Accept": "text/event-stream"}
+    if args.api_key:
+        headers["X-API-Key"] = args.api_key
+
+    print(f"[graphlogue] connecting to {url}")
+    try:
+        response = sse.fetch(url, headers=headers, timeout=args.timeout)
+    except sse.SseError as exc:
+        print(f"[graphlogue] failed to open SSE stream: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        for event in sse.iter_json_events(response):
+            node = store.register_event(event)
+            print(render_event(node))
+            sys.stdout.flush()
+    except KeyboardInterrupt:
+        print("\n[graphlogue] interrupted", file=sys.stderr)
+    finally:
+        response.close()
+    return 0
+
+
+def render_event(node) -> str:
+    label = textwrap.shorten(node.label, width=80, placeholder="...")
+    return f"[{node.run_id}] {node.kind}: {label}"
+
+
+def show_deliverables(store: GraphlogueStore) -> int:
+    deliverables = store.list_deliverables()
+    if not deliverables:
+        print("No deliverables recorded yet.")
+        return 0
+
+    fzf = shutil.which("fzf")
+    if fzf and sys.stdin.isatty() and sys.stdout.isatty():
+        selection = run_fzf(fzf, deliverables)
+        if selection is None:
+            return 0
+        open_deliverable(selection)
+    else:
+        print("Deliverables:")
+        for record in deliverables:
+            summary = textwrap.shorten(record.value.replace("\n", " "), width=90)
+            print(f"- [{record.kind}] {record.label} -> {summary}")
+    return 0
+
+
+def run_fzf(fzf_path: str, deliverables: list[DeliverableRecord]) -> Optional[DeliverableRecord]:
+    lines = []
+    lookup: dict[str, DeliverableRecord] = {}
+    for record in deliverables:
+        summary = textwrap.shorten(record.value.replace("\n", " "), width=72)
+        lines.append(f"{record.id}\t[{record.kind}] {record.label}\t{summary}")
+        lookup[record.id] = record
+
+    proc = subprocess.run(
+        [
+            fzf_path,
+            "--with-nth=2..",
+            "--prompt",
+            "deliverables> ",
+            "--header",
+            "enter to open; esc to quit",
+        ],
+        input="\n".join(lines),
+        text=True,
+        capture_output=True,
+    )
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    selected = proc.stdout.strip().split("\t", 1)[0]
+    return lookup.get(selected)
+
+
+def open_deliverable(record: DeliverableRecord) -> None:
+    print(f"Opening {record.kind} {record.label}")
+    if record.kind == "link":
+        opener = shutil.which("xdg-open") or shutil.which("open")
+        if opener:
+            subprocess.Popen([opener, record.value])
+            return
+        print(record.value)
+    elif record.kind in {"file", "receipt"}:
+        path = Path(record.value)
+        if path.exists():
+            pager = os.environ.get("PAGER") or shutil.which("less")
+            if pager:
+                subprocess.run([pager, str(path)])
+            else:
+                print(path.read_text(encoding="utf-8"))
+        else:
+            print(f"File not found: {path}", file=sys.stderr)
+    else:
+        print(record.value)
+
+
+def export_deliverables(store: GraphlogueStore, destination: Path) -> int:
+    store.export_markdown(destination)
+    print(f"Wrote deliverable summary to {destination}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/graphlogue/demo.py
+++ b/graphlogue/demo.py
@@ -1,0 +1,96 @@
+"""Sample events for the `graphlogue demo` command."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, List
+import uuid
+
+
+def demo_events() -> List[Dict[str, object]]:
+    """Return a deterministic demo timeline."""
+
+    run_id = "demo-run"
+    timestamp = datetime.now(timezone.utc).isoformat()
+    run_node_id = f"run-{uuid.uuid4().hex[:8]}"
+    plan_id = f"plan-{uuid.uuid4().hex[:8]}"
+    write_id = f"write-{uuid.uuid4().hex[:8]}"
+    receipt_id = f"receipt-{uuid.uuid4().hex[:8]}"
+    link_id = f"deliverable-{uuid.uuid4().hex[:8]}"
+    kpi_id = f"kpi-{uuid.uuid4().hex[:8]}"
+    deeplink_id = f"deeplink-{uuid.uuid4().hex[:8]}"
+    table_id = f"table-{uuid.uuid4().hex[:8]}"
+
+    events: List[Dict[str, object]] = [
+        {
+            "kind": "run.start",
+            "label": "Demo run started",
+            "run_id": run_id,
+            "id": run_node_id,
+            "ts": timestamp,
+        },
+        {
+            "kind": "plan",
+            "label": "Plan the work",
+            "run_id": run_id,
+            "parent_id": run_node_id,
+            "id": plan_id,
+            "ts": timestamp,
+        },
+        {
+            "kind": "file.write",
+            "label": "Write README badge",
+            "run_id": run_id,
+            "parent_id": plan_id,
+            "path": "README.md",
+            "id": write_id,
+            "ts": timestamp,
+        },
+        {
+            "kind": "receipt.write",
+            "label": "Recorded file receipt",
+            "run_id": run_id,
+            "path": "receipts/demo.json",
+            "parent_id": write_id,
+            "id": receipt_id,
+            "ts": timestamp,
+        },
+        {
+            "kind": "deliverable",
+            "type": "link",
+            "label": "Demo pull request",
+            "url": "https://example.com/demo-pr",
+            "run_id": run_id,
+            "parent_id": plan_id,
+            "id": link_id,
+            "ts": timestamp,
+        },
+        {
+            "kind": "kpi",
+            "label": "decision_agreement",
+            "value": 0.93,
+            "run_id": run_id,
+            "parent_id": run_node_id,
+            "id": kpi_id,
+            "ts": timestamp,
+        },
+        {
+            "kind": "deeplink",
+            "label": "Open run logs",
+            "url": "https://example.com/runs/demo-run",
+            "run_id": run_id,
+            "parent_id": run_node_id,
+            "id": deeplink_id,
+            "ts": timestamp,
+        },
+        {
+            "kind": "deliverable",
+            "type": "table",
+            "label": "KPI Summary",
+            "md": "| metric | value |\n| --- | --- |\n| decision_agreement | 0.93 |",
+            "run_id": run_id,
+            "parent_id": kpi_id,
+            "id": table_id,
+            "ts": timestamp,
+        },
+    ]
+    return events

--- a/graphlogue/sse.py
+++ b/graphlogue/sse.py
@@ -1,0 +1,86 @@
+"""Tiny Server-Sent Event helpers used by the CLI tools."""
+from __future__ import annotations
+
+import json
+from typing import Dict, Iterable, Iterator, Optional
+import urllib.error
+import urllib.request
+
+
+class SseError(RuntimeError):
+    """Raised when an SSE stream cannot be consumed."""
+
+
+def fetch(url: str, headers: Optional[Dict[str, str]] = None, timeout: int = 30):
+    """Open an SSE stream with urllib.
+
+    The caller is responsible for closing the returned response object.
+    """
+
+    request = urllib.request.Request(url, headers=headers or {})
+    try:
+        return urllib.request.urlopen(request, timeout=timeout)
+    except urllib.error.URLError as exc:  # pragma: no cover - network failure
+        raise SseError(str(exc)) from exc
+
+
+def iter_sse_lines(source: Iterable[bytes]) -> Iterator[Dict[str, str]]:
+    """Convert an iterable of raw HTTP lines into SSE dictionaries."""
+
+    data: list[str] = []
+    event_type = ""
+    event_id = ""
+
+    for raw_line in source:
+        line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+        if not line:
+            if not data:
+                continue
+            payload = "\n".join(data)
+            yield {
+                "event": event_type,
+                "id": event_id,
+                "data": payload,
+            }
+            data = []
+            event_type = ""
+            event_id = ""
+            continue
+        if line.startswith(":"):
+            continue
+        if line.startswith("data:"):
+            data.append(line[5:].lstrip())
+        elif line.startswith("event:"):
+            event_type = line[6:].lstrip()
+        elif line.startswith("id:"):
+            event_id = line[3:].lstrip()
+        else:
+            # Treat the full line as data when the prefix is unknown.
+            data.append(line)
+
+    if data:
+        payload = "\n".join(data)
+        yield {
+            "event": event_type,
+            "id": event_id,
+            "data": payload,
+        }
+
+
+def iter_json_events(source: Iterable[bytes]) -> Iterator[Dict[str, object]]:
+    """Parse JSON events from an SSE byte iterable."""
+
+    for envelope in iter_sse_lines(source):
+        raw = envelope.get("data", "")
+        if not raw:
+            continue
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            event = {"kind": envelope.get("event") or "text", "data": raw}
+        else:
+            if isinstance(event, dict):
+                event.setdefault("kind", envelope.get("event") or event.get("kind") or "event")
+                if envelope.get("id") and "id" not in event:
+                    event["id"] = envelope["id"]
+        yield event

--- a/graphlogue/store.py
+++ b/graphlogue/store.py
@@ -1,0 +1,421 @@
+"""Persistent storage helpers for the Graphlogue terminal tooling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+import uuid
+
+
+@dataclass
+class NodeRecord:
+    """A graph node captured from a streaming event."""
+
+    id: str
+    kind: str
+    label: str
+    run_id: str
+    json_blob: str
+    timestamp: str = ""
+
+
+@dataclass
+class EdgeRecord:
+    """A parent/child edge in the run graph."""
+
+    parent_id: str
+    child_id: str
+    run_id: str
+    kind: str
+
+
+@dataclass
+class DeliverableRecord:
+    """A surfaced artifact for stakeholders."""
+
+    id: str
+    kind: str
+    label: str
+    value: str
+    run_id: str
+    json_blob: str
+
+
+class GraphlogueStore:
+    """Stores nodes, edges, and deliverables in TSV files."""
+
+    def __init__(self, root: Optional[Path] = None) -> None:
+        self.root = Path(root or Path.cwd())
+        self.data_dir = self.root / ".graphlogue"
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+
+        self.nodes_path = self.data_dir / "nodes.tsv"
+        self.edges_path = self.data_dir / "edges.tsv"
+        self.deliverables_path = self.data_dir / "deliverables.tsv"
+
+        self._nodes: Dict[str, NodeRecord] = {}
+        self._edges: Dict[Tuple[str, str], EdgeRecord] = {}
+        self._deliverables: Dict[str, DeliverableRecord] = {}
+        self._counter = 0
+
+        self._load()
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+    def reset(self) -> None:
+        """Remove cached data and clear the TSV files."""
+
+        self._nodes.clear()
+        self._edges.clear()
+        self._deliverables.clear()
+        for path in [self.nodes_path, self.edges_path, self.deliverables_path]:
+            if path.exists():
+                path.unlink()
+        self._counter = 0
+
+    def register_event(self, event: Dict[str, object]) -> NodeRecord:
+        """Store a raw event as a graph node.
+
+        Returns the :class:`NodeRecord` that was persisted. This method also
+        collects deliverables and edges when the event payload contains the
+        corresponding metadata.
+        """
+
+        run_id = _as_str(
+            event.get("run_id")
+            or event.get("run")
+            or event.get("runId")
+            or event.get("thread_id")
+            or "unknown"
+        )
+        kind = _as_str(event.get("kind") or event.get("event") or event.get("type") or "event")
+        node_id = _as_str(
+            event.get("node_id")
+            or event.get("id")
+            or event.get("event_id")
+            or event.get("uuid")
+        )
+
+        if not node_id:
+            node_id = f"{run_id}:{kind}:{self._next_counter()}"
+
+        label = _first_non_empty(
+            event.get("label"),
+            event.get("summary"),
+            event.get("message"),
+            event.get("title"),
+            event.get("name"),
+        ) or kind.replace("_", " ").title()
+
+        timestamp = _as_str(event.get("ts") or event.get("timestamp") or event.get("time") or "")
+        json_blob = json.dumps(event, sort_keys=True, ensure_ascii=False)
+
+        record = NodeRecord(
+            id=node_id,
+            kind=kind,
+            label=_as_str(label),
+            run_id=_as_str(run_id),
+            timestamp=timestamp,
+            json_blob=json_blob,
+        )
+
+        self._nodes[node_id] = record
+        self._write_nodes()
+
+        parent_id = _as_str(
+            event.get("parent_id")
+            or event.get("parent")
+            or event.get("in_reply_to")
+            or event.get("preceding")
+        )
+        if parent_id:
+            edge = EdgeRecord(
+                parent_id=parent_id,
+                child_id=node_id,
+                run_id=record.run_id,
+                kind=kind,
+            )
+            self._edges[(parent_id, node_id)] = edge
+            self._write_edges()
+
+        self._maybe_record_deliverable(event, record)
+
+        return record
+
+    def list_nodes(self) -> List[NodeRecord]:
+        return sorted(self._nodes.values(), key=lambda node: node.timestamp)
+
+    def list_edges(self) -> List[EdgeRecord]:
+        return list(self._edges.values())
+
+    def list_deliverables(self) -> List[DeliverableRecord]:
+        return sorted(
+            self._deliverables.values(),
+            key=lambda deliverable: (deliverable.run_id, deliverable.label),
+        )
+
+    def export_markdown(self, destination: Path) -> None:
+        """Write a stakeholder-friendly deliverables report."""
+
+        deliverables = self.list_deliverables()
+        lines: List[str] = []
+        lines.append("# Run Deliverables")
+        lines.append("")
+        lines.append(
+            f"Generated from {len(deliverables)} artifact(s)."
+        )
+        lines.append("")
+        if not deliverables:
+            lines.append("No deliverables captured yet.")
+        else:
+            lines.append("| Run | Type | Label | Target |")
+            lines.append("| --- | --- | --- | --- |")
+            for deliverable in deliverables:
+                target = _render_target(deliverable)
+                lines.append(
+                    f"| {deliverable.run_id or '-'} | {deliverable.kind} | {deliverable.label} | {target} |"
+                )
+            lines.append("")
+            lines.append("## Detailed Artifacts")
+            lines.append("")
+            for deliverable in deliverables:
+                lines.extend(_render_detail(deliverable))
+                lines.append("")
+
+        destination.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        self._nodes = self._read_nodes()
+        self._edges = self._read_edges()
+        self._deliverables = self._read_deliverables()
+        if self._nodes or self._deliverables:
+            self._counter = max(len(self._nodes), len(self._deliverables))
+        else:
+            self._counter = 0
+
+    def _read_nodes(self) -> Dict[str, NodeRecord]:
+        rows: Dict[str, NodeRecord] = {}
+        if not self.nodes_path.exists():
+            return rows
+        with self.nodes_path.open("r", encoding="utf-8") as handle:
+            for raw_line in handle:
+                line = raw_line.rstrip("\n")
+                if not line:
+                    continue
+                parts = line.split("\t")
+                if len(parts) < 5:
+                    continue
+                node = NodeRecord(
+                    id=parts[0],
+                    kind=parts[1],
+                    label=parts[2],
+                    run_id=parts[3],
+                    json_blob=parts[4],
+                    timestamp=parts[5] if len(parts) > 5 else "",
+                )
+                rows[node.id] = node
+        return rows
+
+    def _read_edges(self) -> Dict[Tuple[str, str], EdgeRecord]:
+        rows: Dict[Tuple[str, str], EdgeRecord] = {}
+        if not self.edges_path.exists():
+            return rows
+        with self.edges_path.open("r", encoding="utf-8") as handle:
+            for raw_line in handle:
+                line = raw_line.rstrip("\n")
+                if not line:
+                    continue
+                parts = line.split("\t")
+                if len(parts) < 4:
+                    continue
+                edge = EdgeRecord(
+                    parent_id=parts[0],
+                    child_id=parts[1],
+                    run_id=parts[2],
+                    kind=parts[3],
+                )
+                rows[(edge.parent_id, edge.child_id)] = edge
+        return rows
+
+    def _read_deliverables(self) -> Dict[str, DeliverableRecord]:
+        rows: Dict[str, DeliverableRecord] = {}
+        if not self.deliverables_path.exists():
+            return rows
+        with self.deliverables_path.open("r", encoding="utf-8") as handle:
+            for raw_line in handle:
+                line = raw_line.rstrip("\n")
+                if not line:
+                    continue
+                parts = line.split("\t")
+                if len(parts) < 5:
+                    continue
+                record = DeliverableRecord(
+                    id=parts[0],
+                    kind=parts[1],
+                    label=parts[2],
+                    value=parts[3],
+                    run_id=parts[4],
+                    json_blob=parts[5] if len(parts) > 5 else "{}",
+                )
+                rows[record.id] = record
+        return rows
+
+    def _write_nodes(self) -> None:
+        with self.nodes_path.open("w", encoding="utf-8") as handle:
+            for node in self._nodes.values():
+                handle.write(
+                    "\t".join(
+                        [
+                            node.id,
+                            node.kind,
+                            node.label,
+                            node.run_id,
+                            node.json_blob,
+                            node.timestamp,
+                        ]
+                    )
+                    + "\n"
+                )
+
+    def _write_edges(self) -> None:
+        if not self._edges:
+            if self.edges_path.exists():
+                self.edges_path.unlink()
+            return
+        with self.edges_path.open("w", encoding="utf-8") as handle:
+            for edge in self._edges.values():
+                handle.write(
+                    "\t".join([edge.parent_id, edge.child_id, edge.run_id, edge.kind]) + "\n"
+                )
+
+    def _write_deliverables(self) -> None:
+        if not self._deliverables:
+            if self.deliverables_path.exists():
+                self.deliverables_path.unlink()
+            return
+        with self.deliverables_path.open("w", encoding="utf-8") as handle:
+            for deliverable in self._deliverables.values():
+                handle.write(
+                    "\t".join(
+                        [
+                            deliverable.id,
+                            deliverable.kind,
+                            deliverable.label,
+                            deliverable.value,
+                            deliverable.run_id,
+                            deliverable.json_blob,
+                        ]
+                    )
+                    + "\n"
+                )
+
+    def _maybe_record_deliverable(self, event: Dict[str, object], node: NodeRecord) -> None:
+        kind = node.kind
+        run_id = node.run_id
+        label = node.label
+        event_id = node.id
+
+        if kind == "deliverable":
+            dtype = _as_str(event.get("type") or event.get("deliverable_type") or "note")
+            value = _first_non_empty(
+                event.get("url"),
+                event.get("path"),
+                event.get("md"),
+                event.get("markdown"),
+                event.get("value"),
+                event.get("text"),
+            ) or ""
+            self._register_deliverable(event_id, dtype, label, _as_str(value), run_id, event)
+        elif kind == "kpi":
+            metric_name = _as_str(event.get("label") or event.get("name") or label or "KPI")
+            value = event.get("value") or event.get("score") or event.get("measurement")
+            value_str = _as_str(value)
+            if event.get("unit"):
+                value_str = f"{value_str} {event['unit']}"
+            self._register_deliverable(event_id, "kpi", metric_name, value_str, run_id, event)
+        elif kind in {"deeplink", "link"}:
+            url = _first_non_empty(event.get("url"), event.get("href"), event.get("uri"))
+            if url:
+                self._register_deliverable(event_id, "link", label, _as_str(url), run_id, event)
+        elif kind.startswith("receipt"):
+            path = _first_non_empty(event.get("path"), event.get("location"))
+            if path:
+                self._register_deliverable(event_id, "receipt", label, _as_str(path), run_id, event)
+        elif kind in {"file.write", "file_proposal"} and event.get("path"):
+            self._register_deliverable(event_id, "file", label, _as_str(event.get("path")), run_id, event)
+
+    def _register_deliverable(
+        self,
+        deliverable_id: Optional[str],
+        kind: str,
+        label: str,
+        value: str,
+        run_id: str,
+        event: Dict[str, object],
+    ) -> None:
+        deliverable_id = _as_str(deliverable_id) or f"deliverable-{uuid.uuid4()}"
+        record = DeliverableRecord(
+            id=deliverable_id,
+            kind=kind,
+            label=_as_str(label) or kind.title(),
+            value=_as_str(value),
+            run_id=_as_str(run_id),
+            json_blob=json.dumps(event, sort_keys=True, ensure_ascii=False),
+        )
+        self._deliverables[record.id] = record
+        self._write_deliverables()
+
+    def _next_counter(self) -> int:
+        self._counter += 1
+        return self._counter
+
+
+def _render_target(deliverable: DeliverableRecord) -> str:
+    value = deliverable.value
+    if deliverable.kind == "link" and value:
+        return f"[Open]({value})"
+    if deliverable.kind in {"file", "receipt"}:
+        return f"`{value}`"
+    if deliverable.kind == "table":
+        return "See below"
+    compact = value.replace("\n", " ")
+    if len(compact) > 96:
+        compact = compact[:93] + "..."
+    return compact or "-"
+
+
+def _render_detail(deliverable: DeliverableRecord) -> List[str]:
+    lines = [f"### {deliverable.label} ({deliverable.kind})", ""]
+    if deliverable.kind == "link":
+        lines.append(f"*Link:* {deliverable.value}")
+    elif deliverable.kind in {"file", "receipt"}:
+        lines.append(f"*Path:* `{deliverable.value}`")
+    elif deliverable.kind == "table" and deliverable.value.strip().startswith("|"):
+        lines.append(deliverable.value.strip())
+    else:
+        lines.append(deliverable.value)
+    lines.append("")
+    lines.append(f"*Run:* {deliverable.run_id or '-'}")
+    return lines
+
+
+def _as_str(value: Optional[object]) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _first_non_empty(*values: Optional[object]) -> Optional[str]:
+    for value in values:
+        text = _as_str(value)
+        if text:
+            return text
+    return None

--- a/graphlogue/swechat.py
+++ b/graphlogue/swechat.py
@@ -1,0 +1,215 @@
+"""Minimal async SWE-style chat client for the terminal."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+import urllib.error
+import urllib.request
+from typing import Dict, Optional
+
+from . import sse
+
+DEFAULT_ENGINE_URL = "http://127.0.0.1:8080"
+SESSION_FILE = "swechat_session.json"
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Stream chat tokens from the engine")
+    parser.add_argument("message", nargs="*", help="Prompt to send to the engine")
+    parser.add_argument("--engine-url", help="Override ENGINE_URL environment variable")
+    parser.add_argument("--api-key", default=os.environ.get("ENGINE_API_KEY"))
+    parser.add_argument("--timeout", type=int, default=45)
+    parser.add_argument("--no-stream", action="store_true", help="Disable SSE mode and use the fallback conversation flow")
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Project root used to persist session metadata (default: current directory)",
+    )
+    args = parser.parse_args(argv)
+
+    message = " ".join(args.message).strip()
+    if not message:
+        message = sys.stdin.read().strip()
+    if not message:
+        print("No message provided.", file=sys.stderr)
+        return 1
+
+    engine_url = args.engine_url or os.environ.get("ENGINE_URL", DEFAULT_ENGINE_URL)
+    if not args.no_stream and try_stream(engine_url, message, args.api_key, args.timeout):
+        return 0
+
+    return run_conversation(engine_url, message, args.api_key, Path(args.root).resolve(), args.timeout)
+
+
+def try_stream(engine_url: str, prompt: str, api_key: Optional[str], timeout: int) -> bool:
+    url = f"{engine_url.rstrip('/')}/chat"
+    payload = json.dumps({"messages": [{"role": "user", "content": prompt}]})
+    headers = {"Content-Type": "application/json", "Accept": "text/event-stream"}
+    if api_key:
+        headers["X-API-Key"] = api_key
+
+    request = urllib.request.Request(url, data=payload.encode("utf-8"), headers=headers, method="POST")
+    try:
+        response = urllib.request.urlopen(request, timeout=timeout)
+    except urllib.error.HTTPError as exc:
+        if exc.code in {404, 405}:
+            return False
+        print(f"/chat error {exc.code}: {exc.reason}", file=sys.stderr)
+        return True
+    except urllib.error.URLError as exc:  # pragma: no cover - network failure
+        print(f"Failed to reach /chat: {exc}", file=sys.stderr)
+        return True
+
+    try:
+        for event in sse.iter_sse_lines(response):
+            data = event.get("data")
+            if data == "[DONE]":
+                break
+            if not data:
+                continue
+            chunk = _extract_text_chunk(data)
+            if chunk:
+                print(chunk, end="", flush=True)
+    finally:
+        response.close()
+    print()
+    return True
+
+
+def _extract_text_chunk(payload: str) -> str:
+    try:
+        body = json.loads(payload)
+    except json.JSONDecodeError:
+        return payload
+    if isinstance(body, dict):
+        delta = body.get("delta")
+        if isinstance(delta, dict):
+            return delta.get("content", "")
+        message = body.get("message")
+        if isinstance(message, dict):
+            return message.get("content", "")
+        return body.get("content") or body.get("text") or ""
+    return str(body)
+
+
+def run_conversation(
+    engine_url: str,
+    prompt: str,
+    api_key: Optional[str],
+    root: Path,
+    timeout: int,
+) -> int:
+    session_path = root / ".graphlogue" / SESSION_FILE
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+    session = _load_session(session_path)
+    branches = session.setdefault("branches", {})
+    branch_id = branches.get(engine_url)
+    if not branch_id:
+        branch_id = _create_branch(engine_url, api_key, timeout)
+        if not branch_id:
+            print("Failed to initialise conversation branch.", file=sys.stderr)
+            return 1
+        branches[engine_url] = branch_id
+        _save_session(session_path, session)
+
+    response = _send_prompt(engine_url, branch_id, prompt, api_key, timeout)
+    if response is None:
+        print("Conversation API returned an error; falling back to /execute_goal.", file=sys.stderr)
+        return run_execute_goal(engine_url, prompt, api_key, timeout)
+
+    print(format_conversation_response(response))
+    return 0
+
+
+def _create_branch(engine_url: str, api_key: Optional[str], timeout: int) -> Optional[str]:
+    payload = json.dumps({"label": "swechat"}).encode("utf-8")
+    url = f"{engine_url.rstrip('/')}/conversation"
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["X-API-Key"] = api_key
+    request = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            branch_id = data.get("branch_id")
+            if isinstance(branch_id, str) and branch_id:
+                return branch_id
+    except urllib.error.URLError as exc:  # pragma: no cover - network failure
+        print(f"Failed to create conversation branch: {exc}", file=sys.stderr)
+    except json.JSONDecodeError:
+        print("Invalid JSON returned from /conversation", file=sys.stderr)
+    return None
+
+
+def _send_prompt(
+    engine_url: str,
+    branch_id: str,
+    prompt: str,
+    api_key: Optional[str],
+    timeout: int,
+) -> Optional[Dict[str, object]]:
+    payload = json.dumps({"prompt": prompt}).encode("utf-8")
+    url = f"{engine_url.rstrip('/')}/conversation/{branch_id}/prompt"
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["X-API-Key"] = api_key
+    request = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+            return json.loads(body)
+    except urllib.error.HTTPError as exc:
+        print(f"Prompt request failed: {exc}", file=sys.stderr)
+    except urllib.error.URLError as exc:  # pragma: no cover - network failure
+        print(f"Prompt request failed: {exc}", file=sys.stderr)
+    except json.JSONDecodeError:
+        print("Prompt response was not valid JSON", file=sys.stderr)
+    return None
+
+
+def run_execute_goal(engine_url: str, prompt: str, api_key: Optional[str], timeout: int) -> int:
+    payload = json.dumps({"goal": prompt}).encode("utf-8")
+    url = f"{engine_url.rstrip('/')}/execute_goal"
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["X-API-Key"] = api_key
+    request = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+            print(body)
+            return 0
+    except urllib.error.URLError as exc:
+        print(f"Failed to call /execute_goal: {exc}", file=sys.stderr)
+        return 1
+
+
+def format_conversation_response(response: Dict[str, object]) -> str:
+    effect = response.get("effect")
+    if isinstance(effect, dict) and effect:
+        key, value = next(iter(effect.items()))
+        pretty = json.dumps({key: value}, indent=2)
+        return f"Effect {key}:\n{pretty}"
+    if response.get("events"):
+        return json.dumps(response["events"], indent=2)
+    return json.dumps(response, indent=2)
+
+
+def _load_session(path: Path) -> Dict[str, object]:
+    if path.exists():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {}
+
+
+def _save_session(path: Path, session: Dict[str, object]) -> None:
+    path.write_text(json.dumps(session, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a Python-based `graphlogue` CLI for following progress streams, capturing deliverables, and exporting run summaries
- introduce a tiny `swechat` chat helper that streams `/chat` tokens when available and falls back to the conversation APIs
- document the new terminal workflow and ignore generated Graphlogue state in version control

## Testing
- ./bin/graphlogue demo
- python -m py_compile $(find graphlogue -name '*.py')


------
https://chatgpt.com/codex/tasks/task_b_68d6a040dc488329850b34bb510b2925