### PR TITLE
feat: support UTIR http.post for Cloudflare integration

### DIFF
--- a/docs/cloudflare_code_mode_setup.md
+++ b/docs/cloudflare_code_mode_setup.md
@@ -1,0 +1,101 @@
+# Cloudflare Code Mode Setup Guide
+
+Cloudflare's Code Mode lets you run Workers AI models with structured tool calls from the Cloudflare dashboard or via the REST API/`wrangler` CLI. The steps below summarize how to get into the beta, obtain the credentials you need, and run the first request locally.
+
+## 1. Request Code Mode access
+1. Sign in to the [Cloudflare Dashboard](https://dash.cloudflare.com/).
+2. Navigate to **Workers & Pages → AI**.
+3. Locate **Code Mode** in the sidebar. If the feature is still in beta, click **Join the beta** and submit the short access form. Cloudflare sends an email once the feature is enabled for your account.
+
+> **Tip:** You must have a verified Cloudflare account (including email and phone verification) and be on a Free, Pro, or higher plan. Enterprise customers should ask their account team to enable Workers AI with Code Mode.
+
+## 2. Create a Workers AI API token
+Code Mode calls Workers AI under the hood. Create a token with the minimum scope:
+
+1. In the dashboard, click your avatar → **My Profile** → **API Tokens**.
+2. Click **Create Token**.
+3. Choose the **Workers AI** template (or create a custom token with the `Workers AI · Read` and `Workers AI · Write` permissions).
+4. Restrict the token to the specific account that will run Code Mode jobs.
+5. Copy the generated token. Store it securely—you cannot view it again after leaving the page.
+
+You also need your **Account ID**. You can find it on **Workers & Pages → Overview** or by running `wrangler whoami` after logging in with the CLI.
+
+## 3. Configure local credentials
+Set the following environment variables before calling the API or running `wrangler` commands:
+
+```bash
+export CLOUDFLARE_ACCOUNT_ID="<your account id>"
+export CLOUDFLARE_API_TOKEN="<token from step 2>"
+```
+
+If you prefer not to use environment variables, create (or update) `~/.config/.wrangler/config/default.toml` with the same values. `wrangler` prompts for these the first time you run `wrangler login` as well.
+
+## 4. Verify access with `wrangler`
+1. Install the CLI: `npm install -g wrangler` (or use `brew install cloudflare-wrangler`).
+2. Authenticate: `wrangler login` (browser flow) or `wrangler config --api-token $CLOUDFLARE_API_TOKEN` for headless environments.
+3. Run `wrangler ai models list` to confirm that Code Mode models (such as `@cf/code-claude-3-7-sonnet` or `@cf/code-llama-70b-instruct`) appear.
+
+If the models list is empty or you receive a permissions error, double-check the token scopes and that Code Mode access has been granted to the account.
+
+## 5. Run your first Code Mode call
+With credentials in place, you can exercise the API directly:
+
+```bash
+curl -X POST \
+  "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run/@cf/code-claude-3-7-sonnet" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          { "type": "text", "text": "Generate a Cloudflare Worker that echos request headers." }
+        ]
+      }
+    ],
+    "metadata": {
+      "mode": "code"
+    }
+  }'
+```
+
+Successful requests return a JSON payload containing the generated code and tool calls. You can supply additional `tools` definitions in the payload to enable deployment or testing actions described in the blog post.
+
+## 6. Keep your tokens safe
+- Treat the API token as a secret. Rotate it from the **API Tokens** page if it leaks.
+- Prefer Cloudflare's **AI Gateway** when exposing Code Mode from production apps; it adds rate limiting and observability on top of Workers AI.
+- For team use, issue separate tokens per developer and restrict them to the minimum necessary account(s).
+
+## Troubleshooting
+| Symptom | Likely Cause | Fix |
+| --- | --- | --- |
+| `403 Unauthorized` when calling the API | Missing or incorrect token scope | Re-create the token with Workers AI read/write permissions. |
+| Code Mode section missing from dashboard | Access not yet granted | Recheck the beta sign-up email or contact Cloudflare support. |
+| `wrangler ai models list` returns only text models | Feature flag not enabled for your account | Wait for the enablement confirmation or ask support to confirm. |
+
+Refer back to the [blog announcement](https://blog.cloudflare.com/code-mode/) for examples of tool definitions and workflow ideas once you have the credentials in place.
+
+## 7. Integrate Code Mode with One Engine
+
+Once Code Mode is working from the CLI you can wire it into One Engine's UTIR pipeline to orchestrate Workers AI runs from conversations or goals:
+
+1. Allow outbound calls to Cloudflare by adding `api.cloudflare.com` to `ENGINE_ALLOWED_DOMAINS` before starting the engine (for example `ENGINE_ALLOWED_DOMAINS="localhost,127.0.0.1,api.cloudflare.com" ./run_dev.sh`).
+2. Define a UTIR document that posts to the Code Mode endpoint using the new `http.post` operation:
+
+   ```yaml
+   task_id: "code-mode-scan"
+   description: "Run Workers AI Code Mode from One Engine"
+   operations:
+     - type: "http.post"
+       url: "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/run/@cf/code-claude-3-7-sonnet"
+       headers:
+         Authorization: "Bearer ${CLOUDFLARE_API_TOKEN}"
+         Content-Type: "application/json"
+       body: |
+         {"messages":[{"role":"user","content":[{"type":"text","text":"Generate a Worker that proxies One Engine"}]}],"metadata":{"mode":"code"}}
+   ```
+
+3. Submit the UTIR through `POST /compile_and_run` or embed it in a conversation branch so the generated Worker artifacts get captured alongside the usual execution receipts.
+
+This pattern lets One Engine broker secure Workers AI calls (using the same Bits telemetry and ledgering as other operations) while Cloudflare handles code synthesis and deployment tooling.

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -156,6 +156,24 @@ impl UtirCompiler {
                     .await?
             }
 
+            Operation::HttpPost {
+                url,
+                headers,
+                body,
+                timeout: timeout_str,
+                max_response_size,
+            } => {
+                self.execute_http_post(
+                    url,
+                    headers,
+                    body.as_deref(),
+                    timeout_str,
+                    max_response_size,
+                    context,
+                )
+                .await?
+            }
+
             Operation::GitPatch {
                 repo_path,
                 patch_content,
@@ -349,6 +367,55 @@ impl UtirCompiler {
         let mut request = client.get(url);
         for (key, value) in headers {
             request = request.header(key, value);
+        }
+
+        match request.send().await {
+            Ok(response) => {
+                if response.status().is_success() {
+                    match response.text().await {
+                        Ok(text) => {
+                            let max_bytes = self.parse_size(max_response_size)?;
+                            if text.len() > max_bytes as usize {
+                                Ok((false, "Response too large".to_string()))
+                            } else {
+                                Ok((true, text))
+                            }
+                        }
+                        Err(e) => Ok((false, format!("Failed to read response: {}", e))),
+                    }
+                } else {
+                    Ok((false, format!("HTTP error: {}", response.status())))
+                }
+            }
+            Err(e) => Ok((false, format!("Request failed: {}", e))),
+        }
+    }
+
+    async fn execute_http_post(
+        &self,
+        url: &str,
+        headers: &HashMap<String, String>,
+        body: Option<&str>,
+        timeout_str: &str,
+        max_response_size: &str,
+        _context: &ExecutionContext,
+    ) -> Result<(bool, String)> {
+        if !self.is_url_allowed(url)? {
+            return Ok((false, "URL not in allowed domains".to_string()));
+        }
+
+        let timeout_duration = self.parse_duration(timeout_str)?;
+        let client = reqwest::Client::builder()
+            .timeout(timeout_duration)
+            .build()?;
+
+        let mut request = client.post(url);
+        for (key, value) in headers {
+            request = request.header(key, value);
+        }
+
+        if let Some(body) = body {
+            request = request.body(body.to_string());
         }
 
         match request.send().await {
@@ -703,7 +770,7 @@ operations:
 
         let utir_yaml = r#"
 task_id: "test-dangerous"
-description: "Dangerous command test"  
+description: "Dangerous command test"
 operations:
   - type: "shell"
     command: "rm -rf /"
@@ -715,5 +782,63 @@ operations:
         assert_eq!(results.len(), 1);
         assert!(!results[0].success);
         assert!(results[0].output.contains("blocked by security"));
+    }
+
+    #[tokio::test]
+    async fn test_http_post_execution() {
+        use axum::{routing::post, Json, Router};
+        use serde_json::{json, Value};
+        use std::time::Duration;
+
+        async fn echo(Json(payload): Json<Value>) -> Json<Value> {
+            let message = payload
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            Json(json!({ "received": message }))
+        }
+
+        let app = Router::new().route("/echo", post(echo));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = axum::serve(listener, app);
+        let server_handle = tokio::spawn(async move {
+            server.await.expect("server error");
+        });
+
+        // Give the server a moment to start
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let mut compiler = UtirCompiler::new(vec!["127.0.0.1".to_string()]).unwrap();
+
+        let utir_yaml = format!(
+            r#"
+task_id: "test-http-post"
+description: "Send JSON payload"
+operations:
+  - type: "http.post"
+    url: "http://{}/echo"
+    headers:
+      Content-Type: "application/json"
+    body: |
+      {{"message":"ping"}}
+"#,
+            addr
+        );
+
+        let doc = parse_utir(&utir_yaml).unwrap();
+        let results = compiler.execute(&doc).await.unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(
+            results[0].success,
+            "HTTP POST should succeed: {}",
+            results[0].output
+        );
+
+        let response: Value = serde_json::from_str(&results[0].output).unwrap();
+        assert_eq!(response["received"], "ping");
+
+        server_handle.abort();
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -416,6 +416,7 @@ impl MemorySystem {
                 crate::utir::Operation::FsRead { .. } => "fs_read",
                 crate::utir::Operation::FsWrite { .. } => "fs_write",
                 crate::utir::Operation::HttpGet { .. } => "http_get",
+                crate::utir::Operation::HttpPost { .. } => "http_post",
                 crate::utir::Operation::GitPatch { .. } => "git_patch",
                 crate::utir::Operation::AssertFileExists { .. } => "assert_file",
                 crate::utir::Operation::AssertShellSuccess { .. } => "assert_shell",

--- a/src/utir.rs
+++ b/src/utir.rs
@@ -75,6 +75,19 @@ pub enum Operation {
         max_response_size: String,
     },
 
+    #[serde(rename = "http.post")]
+    HttpPost {
+        url: String,
+        #[serde(default)]
+        headers: HashMap<String, String>,
+        #[serde(default)]
+        body: Option<String>,
+        #[serde(default = "default_timeout")]
+        timeout: String,
+        #[serde(default = "default_max_response")]
+        max_response_size: String,
+    },
+
     #[serde(rename = "git.patch")]
     GitPatch {
         repo_path: String,


### PR DESCRIPTION
## Summary
- add an `http.post` UTIR operation with compiler execution support and coverage
- include the new HTTP verb in memory pattern signatures
- document how to trigger Cloudflare Code Mode from One Engine using the new operation

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68d80d51152c83299ac5f6d5c03f4323

---
## EntelligenceAI PR Summary 
 This PR adds HTTP POST functionality to the compiler system and provides comprehensive Cloudflare Code Mode setup documentation.
- Added HttpPost variant to Operation enum with URL, headers, body, timeout, and max_response_size fields
- Implemented execute_http_post method with security checks in UtirCompiler
- Extended MemorySystem to support HTTP POST operations
- Created detailed documentation for Cloudflare Code Mode setup with examples and troubleshooting guidance
- Added test cases using Axum mock server to validate HTTP POST functionality 

