### PR TITLE
feat: assemble production branch from merge report

### DIFF
--- a/engine/_output/merge_branches_report.json
+++ b/engine/_output/merge_branches_report.json
@@ -1,0 +1,7 @@
+[
+  {
+    "branch": null,
+    "status": "skipped",
+    "note": "No remote branches were found. Configure remotes, rerun scripts/generate_merge_report.sh, then use scripts/create_production_branch.sh to assemble production."
+  }
+]

--- a/scripts/create_production_branch.sh
+++ b/scripts/create_production_branch.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required to build the production branch" >&2
+  exit 1
+fi
+
+BASE_BRANCH_INPUT="${1:-}"
+TARGET_BRANCH="${2:-production}"
+REPORT_PATH="${3:-engine/_output/merge_branches_report.json}"
+
+current_head_ref="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || git rev-parse --short HEAD)"
+
+if [[ -z "$BASE_BRANCH_INPUT" ]]; then
+  BASE_BRANCH_INPUT="$current_head_ref"
+fi
+
+if [[ ! -f "$REPORT_PATH" ]]; then
+  echo "error: merge report '$REPORT_PATH' was not found" >&2
+  exit 1
+fi
+
+resolve_ref() {
+  local name="$1"
+  local -a candidates=()
+
+  if [[ "$name" == */* ]]; then
+    candidates=("$name")
+  else
+    candidates=("origin/$name" "$name")
+  fi
+
+  local candidate refname
+  for candidate in "${candidates[@]}"; do
+    if [[ "$candidate" == */* ]]; then
+      refname="refs/remotes/$candidate"
+    else
+      refname="refs/heads/$candidate"
+    fi
+
+    if git show-ref --verify --quiet "$refname"; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+base_ref=""
+if ! base_ref=$(resolve_ref "$BASE_BRANCH_INPUT"); then
+  echo "error: base branch '$BASE_BRANCH_INPUT' does not exist" >&2
+  exit 1
+fi
+
+if git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
+  echo "error: target branch '$TARGET_BRANCH' already exists" >&2
+  exit 1
+fi
+
+mapfile -t report_entries < <(jq -c '.[] | select(.branch != null)' "$REPORT_PATH")
+
+if [[ ${#report_entries[@]} -eq 0 ]]; then
+  echo "error: merge report '$REPORT_PATH' did not contain any actionable branches" >&2
+  exit 1
+fi
+
+original_head="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || git rev-parse HEAD)"
+export GIT_MERGE_AUTOEDIT=no
+
+if [[ "$base_ref" == */* ]]; then
+  git fetch --quiet "${base_ref%%/*}" "${base_ref#*/}" >/dev/null 2>&1 || true
+fi
+
+git checkout --quiet -B "$TARGET_BRANCH" "$base_ref"
+
+declare -a skipped
+
+for entry in "${report_entries[@]}"; do
+  branch_name="$(jq -r '.branch' <<<"$entry")"
+  status="$(jq -r '.status' <<<"$entry")"
+
+  case "$status" in
+    merged)
+      echo "info: '$branch_name' already merged into $base_ref; skipping" >&2
+      skipped+=("$branch_name (already merged)")
+      continue
+      ;;
+    fast_forward)
+      ;;
+    *)
+      note="$(jq -r '.note // ""' <<<"$entry")"
+      echo "warn: skipping '$branch_name' due to status '$status'${note:+ - $note}" >&2
+      skipped+=("$branch_name ($status)")
+      continue
+      ;;
+  esac
+
+  if ! ref=$(resolve_ref "$branch_name"); then
+    echo "warn: could not locate branch '$branch_name'; skipping" >&2
+    skipped+=("$branch_name (missing)")
+    continue
+  fi
+
+  echo "info: merging $ref into $TARGET_BRANCH" >&2
+  if ! git merge --no-ff --no-edit "$ref"; then
+    echo "error: merge of '$ref' into '$TARGET_BRANCH' failed" >&2
+    git merge --abort >/dev/null 2>&1 || true
+    if [[ "$original_head" != "$TARGET_BRANCH" ]]; then
+      git checkout --quiet "$original_head"
+    fi
+    exit 1
+  fi
+
+done
+
+if [[ "$original_head" != "$TARGET_BRANCH" ]]; then
+  git checkout --quiet "$original_head"
+fi
+
+if [[ ${#skipped[@]} -gt 0 ]]; then
+  printf 'note: skipped branches -> %s\n' "${skipped[*]}" >&2
+fi
+
+echo "Production branch '$TARGET_BRANCH' created from base '$base_ref'." >&2

--- a/scripts/generate_merge_report.sh
+++ b/scripts/generate_merge_report.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required to generate merge reports" >&2
+  exit 1
+fi
+
+BASE_BRANCH="${1:-}"
+OUTPUT_DIR="engine/_output"
+OUTPUT_JSON="$OUTPUT_DIR/merge_branches_report.json"
+OUTPUT_JSONL="$OUTPUT_JSON.tmp.jsonl"
+
+mkdir -p "$OUTPUT_DIR"
+
+# Capture the current HEAD description for informational messages.
+current_head="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || git rev-parse --short HEAD)"
+
+if [[ -z "$BASE_BRANCH" ]]; then
+  BASE_BRANCH="$current_head"
+fi
+
+if ! git show-ref --verify --quiet "refs/heads/$BASE_BRANCH" && \
+   ! git show-ref --verify --quiet "refs/remotes/$BASE_BRANCH"; then
+  echo "error: base branch '$BASE_BRANCH' does not exist" >&2
+  exit 1
+fi
+
+mapfile -t remote_branches < <(git for-each-ref --format='%(refname:short)' refs/remotes/ | grep -v '/HEAD$' || true)
+
+if [[ ${#remote_branches[@]} -eq 0 ]]; then
+  jq -n '[{branch:null,status:"skipped",note:"No remote branches were found. Configure remotes before regenerating merge status."}]' > "$OUTPUT_JSON"
+  exit 0
+fi
+
+trap 'rm -f "$OUTPUT_JSONL"' EXIT
+> "$OUTPUT_JSONL"
+
+for remote in "${remote_branches[@]}"; do
+  branch_display="${remote#*/}"
+  status="diverged"
+  note="Branches have diverged; manual merge required to reconcile histories."
+
+  if git merge-base --is-ancestor "$remote" "$BASE_BRANCH"; then
+    status="merged"
+    note="Remote branch tip is already merged into $BASE_BRANCH."
+  elif git merge-base --is-ancestor "$BASE_BRANCH" "$remote"; then
+    status="fast_forward"
+    note="Remote branch can fast-forward cleanly into $BASE_BRANCH."
+  fi
+
+  jq -n --arg branch "$branch_display" --arg status "$status" --arg note "$note" \
+    '{branch:$branch,status:$status,note:$note}' >> "$OUTPUT_JSONL"
+done
+
+jq -s '.' "$OUTPUT_JSONL" > "$OUTPUT_JSON"


### PR DESCRIPTION
## Summary
- add a create_production_branch script that consumes the merge report and merges fast-forward branches into a production branch
- update the merge report note to point at the new script when no remotes are configured

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e01d1c23c08329a8589e10b95268e7

---
## EntelligenceAI PR Summary 
 This PR implements an automated branch management workflow system for production branch creation.
- Added `generate_merge_report.sh` to analyze remote branches and create a structured JSON report
- Added `create_production_branch.sh` to perform non-fast-forward merges based on the report
- Created `merge_branches_report.json` to store branch merge status information
- Implemented robust error handling, dependency validation, and detailed logging in both scripts
- Designed the system to preserve the user's original HEAD position and handle various edge cases 

